### PR TITLE
Updates for Fall 2021

### DIFF
--- a/Data_Manipulation_with_Python/Data Manipulation with Python and Pandas.ipynb
+++ b/Data_Manipulation_with_Python/Data Manipulation with Python and Pandas.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "\n",
     "### Goal\n",
-    "By the end of this workshop, we hope you'll be able to load in data into a Pandas `DataFrame`, perform basic cleaning and analysis, and create visualizations of some relevant aspects of a dataset.  For most of this workshop we will work with a dataset prepared from the [IMDb Datasets](https://www.imdb.com/interfaces/) and the [OMDb API](https://www.omdbapi.com/).\n",
+    "By the end of this workshop, we hope you'll be able to load in data into a Pandas `DataFrame`, perform basic cleaning and analysis, and create visualizations of some relevant aspects of a dataset. For most of this workshop we will work with a dataset prepared from the [IMDb Datasets](https://www.imdb.com/interfaces/) and the [OMDb API](https://www.omdbapi.com/).\n",
     "\n",
     "### Topics\n",
     "- What is Pandas?\n",
@@ -63,14 +63,14 @@
    "source": [
     "### Jupyter Notebooks and Google Colaboratory\n",
     "\n",
-    "Jupyter notebooks are a way to write and run Python code in an interactive way. They're quickly becoming a standard way of putting together data, code, and written explanations or visualizations into a single document and sharing that. There are a lot of ways that you can run Jupyter notebooks, including just locally on your computer, but we've decided to use Google's Colaboratory notebook platform for this workshop.  Colaboratory is “a Google research project created to help disseminate machine learning education and research.”  If you would like to know more about Colaboratory in general, you can visit the [Welcome Notebook](https://colab.research.google.com/notebooks/welcome.ipynb).\n",
+    "Jupyter notebooks are a way to write and run Python code in an interactive way. They're quickly becoming a standard way of putting together data, code, and written explanations or visualizations into a single document and sharing that. There are a lot of ways that you can run Jupyter notebooks, including just locally on your computer, but we've decided to use Google's Colaboratory notebook platform for this workshop. Colaboratory is “a Google research project created to help disseminate machine learning education and research.” If you would like to know more about Colaboratory in general, you can visit the [Welcome Notebook](https://colab.research.google.com/notebooks/welcome.ipynb).\n",
     "\n",
     "Using the Google Colaboratory platform allows us to focus on learning and writing Python in the workshop rather than on setting up Python, which can sometimes take a bit of extra work depending on platforms, operating systems, and other installed applications. If you'd like to install a Python distribution locally, though, we have some instructions (with gifs!) on installing Python through the Anaconda distribution, which will also help you handle virtual environments: https://github.com/sul-cidr/Workshops/wiki/Installing-and-Configuring-Anaconda-and-Jupyter-Notebooks\n",
     "\n",
     "If you run into problems, or would like to look into other ways of installing Python or handling virtual environments, feel free to send us an email (contact-cidr@stanford.edu).\n",
     "\n",
     "### Environment\n",
-    "If you would prefer to use Anaconda or your own local installation of python or Jupyter Notebooks, for this workshop you will need an environment with the following packages installed and available:\n",
+    "If you would prefer to use Anaconda or your own local installation of Python or Jupyter Notebooks, for this workshop you will need an environment with the following packages installed and available:\n",
     "- `pandas`\n",
     "- `matplotlib`\n",
     "- `sqlalchemy`\n",
@@ -95,7 +95,7 @@
    "source": [
     "## 1. What is Pandas?\n",
     "\n",
-    "Pandas is a high-level data manipulation tool first created in 2008 by Wes McKinney.  The name is derived from the term “panel data,” an econometrics term for data sets that include observations over multiple time periods for the same individuals.<sup>[[wikipedia](https://en.wikipedia.org/wiki/Pandas_(software))]</sup>\n",
+    "Pandas is a high-level data manipulation tool first created in 2008 by Wes McKinney. The name is derived from the term “panel data,” an econometrics term for data sets that include observations over multiple time periods for the same individuals.<sup>[[wikipedia](https://en.wikipedia.org/wiki/Pandas_(software))]</sup>\n",
     "\n",
     "From Jake Vanderplas’ book [**Python Data Science Handbook**](http://shop.oreilly.com/product/0636920034919.do):\n",
     "\n",
@@ -113,7 +113,7 @@
     "import pandas as pd\n",
     "\n",
     "# The two lines below configure how our outputs are shown in this notebook\n",
-    "#  environment.  They need not concern us now.\n",
+    "# environment. They need not concern us now.\n",
     "pd.set_option('display.max_rows', 20)\n",
     "pd.DataFrame._repr_html_ = \\\n",
     "    lambda self: ('<style>table.dataframe td {white-space: nowrap}</style>' +\n",
@@ -162,7 +162,7 @@
    "source": [
     "### 1.2. Where can I get more help with Pandas?\n",
     "\n",
-    "The [Pandas website](https://pandas.pydata.org/) and [online documentation](http://pandas.pydata.org/pandas-docs/stable/) are useful resources, and of course the indispensible [Stack Overflow has a \"pandas\" tag](https://stackoverflow.com/questions/tagged/pandas).  There is also a (much younger, much smaller) [sister site dedicated to Data Science questions that has a \"pandas\" tag](https://datascience.stackexchange.com/questions/tagged/pandas) too."
+    "The [Pandas website](https://pandas.pydata.org/) and [online documentation](http://pandas.pydata.org/pandas-docs/stable/) are useful resources, and of course the indispensible [Stack Overflow has a \"pandas\" tag](https://stackoverflow.com/questions/tagged/pandas). There is also a (much younger, much smaller) [sister site dedicated to Data Science questions that has a \"pandas\" tag](https://datascience.stackexchange.com/questions/tagged/pandas) too."
    ]
   },
   {
@@ -182,15 +182,15 @@
     "id": "tCDLHdEmcGtE"
    },
    "source": [
-    "## 2. Introduction to `DataFrame`  s and `Series`\n",
+    "## 2. Introduction to `DataFrame`s and `Series`\n",
     "\n",
-    "The main data structure that Pandas implements is the `DataFrame`, and a `DataFrame` is composed of one or more `Series` and, optionally, an `Index`.  \n",
+    "The main data structure that Pandas implements is the `DataFrame`, and a `DataFrame` is composed of one or more `Series` and, optionally, an `Index`. \n",
     "\n",
     "A `DataFrame` is a two-dimensional array with flexible row indices and flexible column names. It can be thought of as a generalization of a two-dimensional NumPy array, or a specialization of a dictionary in which each column name maps to a `Series` of column data.\n",
     "\n",
     "A `Series` is a one-dimensional array of indexed data. It can be thought of as a specialized dictionary or a generalized NumPy array.\n",
     "\n",
-    "A `DataFrame` is made up of `Series` in a similar way in which a table is made up of columns. The only restriction is that each column must be of the same data type.  Many of the operations that can be performed on a `DataFrame` can also be performed on an individual `Series`.\n",
+    "A `DataFrame` is made up of `Series` in a similar way in which a table is made up of columns. The only restriction is that each column must be of the same data type. Many of the operations that can be performed on a `DataFrame` can also be performed on an individual `Series`.\n",
     "\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/sul-cidr/Workshops/master/Data_Manipulation_with_Python/assets/dataframes.png\" alt=\"DataFrames are composed of Series\">"
@@ -254,7 +254,7 @@
    },
    "outputs": [],
    "source": [
-    "bay_area_counties = pd.DataFrame(data, index=[\"Ala\", \"Con\", \"Mar\", \"Nan\", \"SF\", \"SM\", \"SC\", \"Sol\", \"Son\"])\n",
+    "bay_area_counties = pd.DataFrame(data, index=[\"Ala\", \"Con\", \"Mar\", \"Nap\", \"SF\", \"SM\", \"SC\", \"Sol\", \"Son\"])\n",
     "bay_area_counties"
    ]
   },
@@ -296,7 +296,7 @@
    "outputs": [],
    "source": [
     "bay_area_counties = pd.DataFrame(data)\n",
-    "bay_area_counties.index = [\"Ala\", \"Con\", \"Mar\", \"Nan\", \"SF\", \"SM\", \"SC\", \"Sol\", \"Son\"]\n",
+    "bay_area_counties.index = [\"Ala\", \"Con\", \"Mar\", \"Nap\", \"SF\", \"SM\", \"SC\", \"Sol\", \"Son\"]\n",
     "bay_area_counties"
    ]
   },
@@ -415,7 +415,7 @@
     "\n",
     "There are two things to note here:\n",
     "\n",
-    "1. the nature of JSON as a file format is such that the `Index` is explicit, and Pandas will set it correctly for us initially.\n",
+    "1. The nature of JSON as a file format is such that the `Index` is explicit, and Pandas will set it correctly for us initially.\n",
     "2. We're loading the data directly over HTTP(S) here -- Pandas `read_...` methods can accept a local file path or a URL, and Pandas will take care of fetching the data for you."
    ]
   },
@@ -438,7 +438,7 @@
    "source": [
     "#### 3.2.3. Reading data via a SQL query\n",
     "\n",
-    "We can also load data from relational databases or other datastores that export a SQL-compatible interface.  For this example we'll download a simple SQLite database file to operate on, but Pandas’ `read_sql*` methods can accept a `connection` object that is predicated on a remote database server if required."
+    "We can also load data from relational databases or other datastores that export a SQL-compatible interface. For this example we'll download a simple SQLite database file to operate on, but Pandas’ `read_sql*` methods can accept a `connection` object that is predicated on a remote database server if required."
    ]
   },
   {
@@ -475,7 +475,7 @@
    "source": [
     "#### 3.2.3. Other input formats\n",
     "\n",
-    "Pandas also has methods that allow it to read data directly from other formats, including those used by Microsoft Excel, Stata, SAS, and Google Big Query.  More details are available from the [Pandas documentation](https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html)."
+    "Pandas also has methods that allow it to read data directly from other formats, including those used by Microsoft Excel, Stata, SAS, and Google Big Query. More details are available from the [Pandas documentation](https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html)."
    ]
   },
   {
@@ -493,7 +493,7 @@
     "id": "nFqPRBMwcGt5"
    },
    "source": [
-    "Pandas makes writing data to persistent storage formats similarly convenient.  Methods are available to write to most of the formats Pandas can read, including all those demonstrated above."
+    "Pandas makes writing data to persistent storage formats similarly convenient. Methods are available to write to most of the formats Pandas can read, including all those demonstrated above."
    ]
   },
   {
@@ -517,7 +517,7 @@
     "\n",
     "Let's begin by loading our dataset of the top 1,000 ranked films on imDB.\n",
     "\n",
-    "In the same way that it's common to `import pandas as pd`, it's common to use `df` as an identifier for generic `DataFrame`s, especially in tutorials and demos.  For anything other than interactive sessions or throw-away scripts, however, we strongly recommend using good descriptive identifiers for your `DataFrame`s!"
+    "In the same way that it's common to `import pandas as pd`, it's common to use `df` as an identifier for generic `DataFrame`s, especially in tutorials and demos. For anything other than interactive sessions or throw-away scripts, however, we strongly recommend using good descriptive identifiers for your `DataFrame`s!"
    ]
   },
   {
@@ -581,7 +581,7 @@
     "id": "4hfSMq3kcGuL"
    },
    "source": [
-    "Accessing columns can be done using the dot notation, `df.column_name`, or the dictionary notation, `df['column_name']`.  This returns a `Series` object."
+    "Accessing columns can be done using the dot notation, `df.column_name`, or the dictionary notation, `df['column_name']`. This returns a `Series` object."
    ]
   },
   {
@@ -603,7 +603,7 @@
    },
    "outputs": [],
    "source": [
-    "type(df.Title)"
+    "type(df['Title'])"
    ]
   },
   {
@@ -778,7 +778,7 @@
     "id": "jUoVE-DMcGus"
    },
    "source": [
-    "We briefly saw the `.loc` attribute above which allows selection by “label” -- that is, by value(s) in the `Index`.  `DataFrame`s also expose the `.iloc` attribute, which is for selection by (integer-based) position:"
+    "We briefly saw the `.loc` attribute above which allows selection by “label” -- that is, by value(s) in the `Index`. `DataFrame`s also expose the `.iloc` attribute, which is for selection by (integer-based) position:"
    ]
   },
   {
@@ -821,7 +821,7 @@
    "source": [
     "#### 4.2.1 Copying and sorting `DataFrame`s\n",
     "\n",
-    "`DataFrame`s provide the `.sort_values()` method to allow sorting on multiple columns.  Typically we want to sort our data temporarily at time of output -- either as we’re displaying or saving it:"
+    "`DataFrame`s provide the `.sort_values()` method to allow sorting on multiple columns. Typically we want to sort our data temporarily at time of output -- either as we’re displaying or saving it:"
    ]
   },
   {
@@ -841,9 +841,9 @@
     "id": "pkwXahSacGuz"
    },
    "source": [
-    "However, sometimes we actually want to change the way in which the observations are ordered in a `DataFrame` in a way which persists, and we can do this using the `inplace=True` argument to the `.sort_values()` method.\n",
+    "However, sometimes we actually want to change the way in which the observations are ordered in a `DataFrame` in a persistent way, and we can do this using the `inplace=True` argument to the `.sort_values()` method.\n",
     "\n",
-    "To demonstrate this, we're going to reset the index on the `DataFrame` so that observations are given a simple ordinal index.  Since we don't want to change our `DataFrame` for the following examples, we'll make a `.copy()` to operate on."
+    "To demonstrate this, we're going to reset the index on the `DataFrame` so that observations are given a simple ordinal index. Since we don't want to change our `DataFrame` for the following examples, we'll make a `.copy()` to operate on."
    ]
   },
   {
@@ -944,14 +944,10 @@
    },
    "outputs": [],
    "source": [
-    "#@title → Double-click Here to Show/Hide a Prepared Solution\n",
+    "#@title → Double-click Here to Show/Hide a Prepared Solution { form-width: \"20%\" }\n",
     "df[['Title','Year','imdbRating','imdbVotes']]\\\n",
     "    .sort_values(['imdbRating', 'imdbVotes'], ascending=[False, False])\\\n",
-    "    .head(5)\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n"
+    "    .head(5)"
    ]
   },
   {
@@ -1001,7 +997,7 @@
    },
    "outputs": [],
    "source": [
-    "df.Title + '(' + df.Rated + '), directed by: ' + df.Director"
+    "df.Title + '(' + df.Rated + '), directed by ' + df.Director"
    ]
   },
   {
@@ -1061,7 +1057,7 @@
     "id": "1PVnp1f3cGvN"
    },
    "source": [
-    "Any expression that evaluates to a `Series` of boolean values (`True` or `False`) and shares the same `Index` as the source `DataFrame` can be used.  Complex conditions can be assembled using bitwise logical operators `&`, `|`, and `~` to create simple but powerful filters."
+    "Any expression that evaluates to a `Series` of boolean values (`True` or `False`) and shares the same `Index` as the source `DataFrame` can be used. Complex conditions can be assembled using bitwise logical operators `&`, `|`, and `~` to create simple but powerful filters."
    ]
   },
   {
@@ -1193,7 +1189,7 @@
     "    \"county\": [\"Alameda\", \"Contra Costa\", \"Marin\", \"Napa\", \"San Francisco\", \"San Mateo\", \"Santa Clara\", \"Solano\", \"Sonoma\"],\n",
     "    \"county seat\": [\"Oakland\", \"Martinez\", \"San Rafael\", \"Napa\", \"San Francisco\", \"Redwood City\", \"San Jose\", \"Fairfield\", \"Santa Rosa\"],\n",
     "    \"population\": [1494876, 1037817, 250666, 135377, 870887, 711622, 1762754, 411620, 478551],\n",
-    "    \"area\": [2130, 2080, 2140, 2040, 600.59, 1930, 3380, 2350, 4580]  # data is in km²\n",
+    "    \"area\": [2130, 2080, 2140, 2040, 600.59, 1930, 3380, 2350, 4580] # data is in km²\n",
     "}\n",
     "bay_area_counties = pd.DataFrame(data)\n",
     "bay_area_counties"
@@ -1207,7 +1203,7 @@
    },
    "outputs": [],
    "source": [
-    "# Write your code here\n"
+    "# Write your code here"
    ]
   },
   {
@@ -1219,7 +1215,7 @@
    },
    "outputs": [],
    "source": [
-    "#@title → Double-click Here to Show/Hide a Prepared Solution\n",
+    "#@title → Double-click Here to Show/Hide a Prepared Solution { form-width: \"20%\" }\n",
     "bay_area_counties['pop. density'] = bay_area_counties.population / bay_area_counties.area"
    ]
   },
@@ -1240,7 +1236,7 @@
    "source": [
     "#### 4.4.1. Converting data types\n",
     "\n",
-    "Pandas does a pretty good job of inferring data types when we load data into a `DataFrame`, but sometimes we want or need to change the types it selects.  We can do this using the `.astype()` method on a `Series` object."
+    "Pandas does a pretty good job of inferring data types when we load data into a `DataFrame`, but sometimes we want or need to change the types it selects. We can do this using the `.astype()` method on a `Series` object."
    ]
   },
   {
@@ -1270,7 +1266,7 @@
     "id": "3Zn4NH7icGvq"
    },
    "source": [
-    "Using `.astype('category')` invokes the default behavior, by which categories are inferred from the data and are unordered.  The only real advantage to using categories is if they are ordered, so let's quickly convert them to ordered categories:"
+    "Using `.astype('category')` invokes the default behavior, by which categories are inferred from the data and are unordered. The only real advantage to using categories is if they are ordered, so let's quickly convert them to ordered categories:"
    ]
   },
   {
@@ -1347,7 +1343,7 @@
    "source": [
     "#### 4.4.2. `.apply()`\n",
     "\n",
-    "The `apply()` method has appeared a couple of times above. This is the fundamental way of manipulating the contents of `DataFrame`s.  `apply()` takes a function as an argument, and `apply`s the function to each element in the container it’s called on."
+    "The `apply()` method has appeared a couple of times above. This is the fundamental way of manipulating the contents of `DataFrame`s. `apply()` takes a function as an argument, and `apply`s the function to each element in the container it’s called on."
    ]
   },
   {
@@ -1449,7 +1445,7 @@
     "id": "R9C7h36PcGv_"
    },
    "source": [
-    "One possible problem with this approach is that we don't get a count for the observations with missing values.  This means that if we want to enrich our original `DataFrame` with a new column containing the genre count, our count column will also be populated with `NaN`s:"
+    "One possible problem with this approach is that we don't get a count for the observations with missing values. This means that if we want to enrich our original `DataFrame` with a new column containing the genre count, our count column will also be populated with `NaN`s:"
    ]
   },
   {
@@ -1506,7 +1502,7 @@
     "id": "fq8vve5QcGwE"
    },
    "source": [
-    "For the sake of our workshop, however, the dataset has been modified so that `Genre` has been removed where it should be the single value “Comedy”.  Since we know, therefore, what the value should be for all observations where `Genre` is missing, we have the option to simply update the `DataFrame` directly in the following way:"
+    "For the sake of our workshop, however, the dataset has been modified so that `Genre` has been removed where it should be the single value “Comedy”. Since we know, therefore, what the value should be for all observations where `Genre` is missing, we have the option to simply update the `DataFrame` directly in the following way:"
    ]
   },
   {
@@ -1633,7 +1629,7 @@
    },
    "outputs": [],
    "source": [
-    "#@title → Double-click Here to Show/Hide Hints\n",
+    "#@title → Double-click Here to Show/Hide Hints { form-width: \"20%\" }\n",
     "\n",
     "# 1. You'll probably want to write a helper\n",
     "#    function to count the languages\n",
@@ -1655,7 +1651,7 @@
    },
    "outputs": [],
    "source": [
-    "#@title → Double-click Here to Show/Hide a Prepared Solution\n",
+    "#@title → Double-click Here to Show/Hide a Prepared Solution { form-width: \"20%\" }\n",
     "\n",
     "def count_languages(langs):\n",
     "    return len(langs.split(', '))\n",
@@ -1672,7 +1668,7 @@
    "source": [
     "### 4.5. Aggregating data\n",
     "\n",
-    "But what about the most-featured Director in the top 1000 list?  Or the average rating for movies classified as “Comedy”?  For these kinds of operations we need to compute across aggregations of the dataset.  In Pandas this may be accomplished by means of `.groupby()` operation followed by an `.aggregate()` function. Aggregates can be considered a form of `.apply()` that operates on a collection of observations at once (in these cases, on the collections created by `.groupby()`.\n",
+    "But what about the most-featured Director in the top 1000 list? Or the average rating for movies classified as “Comedy”? For these kinds of operations we need to compute across aggregations of the dataset. In Pandas this may be accomplished by means of `.groupby()` operation followed by an `.aggregate()` function. Aggregates can be considered a form of `.apply()` that operates on a collection of observations at once (in these cases, on the collections created by `.groupby()`.\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/sul-cidr/Workshops/master/Data_Manipulation_with_Python/assets/aggregation.png\" alt=\"Aggregation\">\n",
     "\n",
@@ -1818,7 +1814,7 @@
    },
    "outputs": [],
    "source": [
-    "#@title → Double-click Here to Show/Hide a Prepared Solution\n",
+    "#@title → Double-click Here to Show/Hide a Prepared Solution { form-width: \"20%\" }\n",
     "df[df.Genre.str.contains('Comedy')].groupby('Year')[['Title']].aggregate(len).sort_values(['Title'], ascending=False).head(5)"
    ]
   },
@@ -1854,7 +1850,7 @@
    },
    "outputs": [],
    "source": [
-    "df.groupby('Year')[['Year']].aggregate(len).plot()\n",
+    "df.groupby('Year')[['Year']].aggregate(len).plot(ylabel=\"Films\", legend=False)\n",
     "df.groupby('Year')[['Year']].aggregate(len)"
    ]
   },
@@ -1878,7 +1874,7 @@
     "# Reindexing by the full year range, step value=1, assigns NaN for the missing years\n",
     "df_gapped = df.groupby('Year')[['Year']].aggregate(len)\n",
     "df_gapped = df_gapped.reindex(range(df_gapped.index.min(),df_gapped.index.max()+1,1))\n",
-    "df_gapped.plot()\n",
+    "df_gapped.plot(ylabel=\"Films\", legend=False)\n",
     "df_gapped"
    ]
   },
@@ -1890,7 +1886,7 @@
    },
    "outputs": [],
    "source": [
-    "df_gapped.fillna(value=0).plot()"
+    "df_gapped.fillna(value=0).plot(ylabel=\"Films\", legend=False)"
    ]
   },
   {
@@ -1903,7 +1899,7 @@
    "source": [
     "interp_method = \"quadratic\" # Other options: slinear, cubic, spline\n",
     "df_yearly = df_gapped.interpolate(method=interp_method)\n",
-    "df_yearly.plot()\n",
+    "df_yearly.plot(ylabel=\"Films\", legend=False)\n",
     "df_yearly"
    ]
   },
@@ -1928,7 +1924,7 @@
     "    kind=\"bar\",\n",
     "    figsize=(15, 5),\n",
     "    title=\"# Movies per Year\",\n",
-    "    legend=None\n",
+    "    legend=False\n",
     ")\n",
     "ax.set_ylabel(\"# Movies\")\n",
     "ax.set_xlabel(\"Year of Release\")"
@@ -1954,7 +1950,7 @@
    "outputs": [],
    "source": [
     "with plt.style.context('ggplot'):\n",
-    "    df_yearly.plot()"
+    "    df_yearly.plot(ylabel=\"Films\", legend=False)"
    ]
   },
   {
@@ -1966,8 +1962,8 @@
    "outputs": [],
    "source": [
     "with plt.xkcd():\n",
-    "    df_yearly.plot()\n",
-    "plt.rcdefaults()  # this is needed as the XKCD style is a special case"
+    "    df_yearly.plot(ylabel=\"Films\", legend=False)\n",
+    "plt.rcdefaults() # this is needed as the XKCD style is a special case"
    ]
   },
   {
@@ -1979,10 +1975,11 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, figsize=(15, 5))\n",
+    "ax.set_title('Histogram of # votes')\n",
+    "ax.set_xlabel(\"Votes\")\n",
     "plt.ticklabel_format(style='plain')\n",
     "df['imdbVotes'].hist(ax=ax, bins=15, density=True, color='lightseagreen')\n",
-    "df['imdbVotes'].plot(ax=ax, kind='kde', xlim=(0, 2200000), style='r--')\n",
-    "ax.set_title('Histogram of # votes')"
+    "df['imdbVotes'].plot(ax=ax, kind='kde', xlim=(0, 2200000), style='r--')"
    ]
   },
   {
@@ -1996,20 +1993,6 @@
     "fig, ax = plt.subplots(1, figsize=(6, 6))\n",
     "plt.ticklabel_format(style='plain')\n",
     "df.boxplot(column='imdbVotes', by='Rated', grid=False, ax=ax, sym='')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "pRZtBuOVcGwo"
-   },
-   "outputs": [],
-   "source": [
-    "import seaborn as sns\n",
-    "fig, ax = plt.subplots(1, figsize=(6, 6))\n",
-    "plt.ticklabel_format(style='plain')\n",
-    "sns.violinplot(y=df['imdbVotes'], grid=False, ax=ax)"
    ]
   },
   {


### PR DESCRIPTION
The primarily update to the workshop in this PR is the removal of the single code cell that requires `seaborn`. The cell was pretty superfluous anyway, and removing it helps to get rid of an equally unnecessary external library dependency.

Other changes:
- Some double-spaces have been turned into single spaces, initially just because that worked better with my editor, but I actually do think that most of them also are valid, formatting-wise.
- Abbreviation for "Napa" is changed from "Nan" (which looks a bit confusing) to "Nap".
- Minor wording updates.
- Legends are removed from all of the visualizations that don't need a legend.
- The hidden solutions to the activities now take up 80% of the cell width when revealed, rather than 50%.

It's definitely worth re-checking (again) whether the notebook still works as intended from beginning to end. For what it's worth, everything seemed to work fine when I reloaded this in Colab. Interestingly, some of the cells beginning at
`df[pd.isna(df.Genre)][['Title', 'Genre']]`
failed with some cryptic errors when run in a Jupyter notebook on my local machine (Python 3.7.4, Pandas 1.1.0), but they work fine in Colab, and presumably would be OK in a newer environment on my machine.